### PR TITLE
Add basic web test harness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["rust-core"]
+members = ["rust-core", "wasm-bindings"]
 resolver = "2"

--- a/wasm-bindings/Cargo.toml
+++ b/wasm-bindings/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "pinniped-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+pinniped-core = { path = "../rust-core" }
+wasm-bindgen = "0.2"

--- a/wasm-bindings/build.sh
+++ b/wasm-bindings/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+wasm-pack build --target web --release

--- a/wasm-bindings/src/lib.rs
+++ b/wasm-bindings/src/lib.rs
@@ -1,0 +1,15 @@
+use wasm_bindgen::prelude::*;
+use pinniped_core::document::Document;
+
+#[wasm_bindgen]
+pub fn parse(markdown: &str) -> Result<JsValue, JsValue> {
+    let doc = Document::parse(markdown).map_err(|e| JsValue::from_str(&e.to_string()))?;
+    JsValue::from_serde(&doc.blocks).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+#[wasm_bindgen]
+pub fn to_markdown(blocks: &JsValue) -> Result<String, JsValue> {
+    let blocks: Vec<pinniped_core::block::Block> = blocks.into_serde().map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let doc = Document { blocks };
+    Ok(doc.to_markdown())
+}

--- a/web-test/index.html
+++ b/web-test/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Pinniped Web Test</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Pinniped Markdown Parser Test</h1>
+    <textarea id="markdown-input" placeholder="Enter markdown here"></textarea>
+    <button id="parse-button">Parse</button>
+    <h2>Round Trip Output</h2>
+    <pre id="output"></pre>
+
+    <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/web-test/main.js
+++ b/web-test/main.js
@@ -1,0 +1,14 @@
+import init, { parse, to_markdown } from '../wasm-bindings/pkg/pinniped_wasm.js';
+
+async function run() {
+    await init();
+    const input = document.getElementById('markdown-input');
+    const output = document.getElementById('output');
+    document.getElementById('parse-button').addEventListener('click', () => {
+        const result = parse(input.value);
+        const roundTrip = to_markdown(result);
+        output.textContent = roundTrip;
+    });
+}
+
+run();

--- a/web-test/serve.sh
+++ b/web-test/serve.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+python3 -m http.server --directory . 8080

--- a/web-test/style.css
+++ b/web-test/style.css
@@ -1,0 +1,14 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 2rem;
+}
+
+textarea {
+    width: 100%;
+    height: 150px;
+}
+
+pre {
+    background: #f5f5f5;
+    padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- extend workspace to include wasm bindings
- implement minimal WASM wrapper around the Rust core
- add build script for WASM
- create simple web test interface with JS and CSS
- include helper script for running a dev server

## Testing
- `cargo test -p pinniped-core` *(fails: failed to download wasm-bindgen dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6881a681c8cc832ca7083d8543f54d29